### PR TITLE
Update the package.json dependencies to match the ones used in assets folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,16 @@
   "private": true,
   "devDependencies": {
     "gulp": "^3.8.8",
+    "gulp-notify": "^3.2.0",
     "laravel-elixir-webpack": "^1.0.1"
   },
   "dependencies": {
-    "bootstrap-sass": "^3.0.0",
+    "angular": "^1.4.5",
+    "angular-ui-router": "^0.4.2",
+    "bootstrap-sass": "^3.3.7",
+    "bootstrap-notify": "^3.1.3",
+    "clipboard": "^2.0.4",
+    "jquery": "^3.1.1",
     "laravel-echo": "^1.3.5",
     "laravel-elixir": "^4.0.0",
     "pusher-js": "^4.2.2"


### PR DESCRIPTION
The npm build process currently fails without these - I've tried to match to what I could see in you latest asset commits (from the comments).