### PR TITLE
Enable Syntax Highlight and automatic formatting of JSON and XML

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,3 +38,5 @@ RUN php artisan optimize && php artisan migrate
 ADD --chown=www-data:www-data /resources /var/www/html/resources
 COPY --chown=www-data:www-data --from=npm /app/public/css /var/www/html/public/css
 COPY --chown=www-data:www-data --from=npm /app/public/js /var/www/html/public/js
+
+USER root

--- a/package-lock.json
+++ b/package-lock.json
@@ -9363,6 +9363,11 @@
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
+    "pretty-data": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/pretty-data/-/pretty-data-0.40.0.tgz",
+      "integrity": "sha1-Vyqo6iNGdGerlLa1Jmpv2cj93XI="
+    },
     "pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -181,6 +181,15 @@
       "resolved": "https://registry.npmjs.org/angular/-/angular-1.7.8.tgz",
       "integrity": "sha512-wtef/y4COxM7ZVhddd7JtAAhyYObq9YXKar9tsW7558BImeVYteJiTxCKeJOL45lJ/+7B4wrAC49j8gTFYEthg=="
     },
+    "angular-highlightjs": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/angular-highlightjs/-/angular-highlightjs-0.7.1.tgz",
+      "integrity": "sha1-1+Dh9Z203mPwBXMhimRypZ/xg/Q=",
+      "requires": {
+        "angular": "^1.0.1",
+        "highlight.js": ">7.0.0"
+      }
+    },
     "angular-ui-router": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/angular-ui-router/-/angular-ui-router-0.4.3.tgz",
@@ -3348,7 +3357,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3369,12 +3379,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3389,17 +3401,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3516,7 +3531,8 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3528,6 +3544,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3542,6 +3559,7 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3549,12 +3567,14 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3573,6 +3593,7 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3653,7 +3674,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3665,6 +3687,7 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3750,7 +3773,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3786,6 +3810,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3805,6 +3830,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3848,12 +3874,14 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "optional": true
         }
       }
     },
@@ -5772,6 +5800,11 @@
         "hoek": "2.x.x",
         "sntp": "1.x.x"
       }
+    },
+    "highlight.js": {
+      "version": "9.15.6",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.6.tgz",
+      "integrity": "sha512-zozTAWM1D6sozHo8kqhfYgsac+B+q0PmsjXeyDrYIHHcBN0zTVT66+s2GW1GZv7DbyaROdLXKdabwS/WqPyIdQ=="
     },
     "hmac-drbg": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "jquery": "^3.1.1",
     "laravel-echo": "^1.3.5",
     "laravel-elixir": "^4.0.0",
+    "pretty-data": "^0.40.0",
     "pusher-js": "^4.2.2"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
   },
   "dependencies": {
     "angular": "^1.4.5",
+    "angular-highlightjs": "^0.7.1",
     "angular-ui-router": "^0.4.2",
-    "bootstrap-sass": "^3.3.7",
     "bootstrap-notify": "^3.1.3",
+    "bootstrap-sass": "^3.3.7",
     "clipboard": "^2.0.4",
+    "highlight.js": "^9.15.6",
     "jquery": "^3.1.1",
     "laravel-echo": "^1.3.5",
     "laravel-elixir": "^4.0.0",

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -1,6 +1,7 @@
 angular
     .module("app", [
-        'ui.router'
+        'ui.router',
+        'hljs'
     ])
     .config(['$stateProvider', '$urlRouterProvider', '$urlMatcherFactoryProvider',
         function ($stateProvider, $urlRouterProvider, $urlMatcherFactoryProvider) {
@@ -185,7 +186,12 @@ angular
 
         $scope.setCurrentRequest = (function (request) {
             $scope.currentRequestIndex = request.uuid;
-            $scope.currentRequest = request;
+            $scope.currentRequest = JSON.parse(JSON.stringify(request));
+
+            if ($scope.formatJsonEnable) {
+                $scope.currentRequest.content = $scope.formatContentJson(request.content)
+            }
+
             $scope.markAsRead(request.uuid);
 
             // Change the state url so it may be copied from address bar

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -1,3 +1,5 @@
+var prettyData = require('pretty-data').pd;
+
 angular
     .module("app", [
         'ui.router',
@@ -189,7 +191,14 @@ angular
             $scope.currentRequest = JSON.parse(JSON.stringify(request));
 
             if ($scope.formatJsonEnable) {
-                $scope.currentRequest.content = $scope.formatContentJson(request.content)
+                var hloutput = hljs.highlightAuto(request.content);
+
+                if (hloutput.language === "json") {
+                    $scope.currentRequest.content = $scope.formatContentJson(request.content)
+                }
+                if (hloutput.language === "xml") {
+                    $scope.currentRequest.content = prettyData.xml(request.content);
+                }
             }
 
             $scope.markAsRead(request.uuid);

--- a/resources/assets/js/libs.js
+++ b/resources/assets/js/libs.js
@@ -4,3 +4,11 @@ require('bootstrap-notify');
 require('angular');
 require('angular-ui-router');
 window.Clipboard = require('clipboard');
+
+window.hljs = require('highlight.js/lib/highlight');
+var javascript = require('highlight.js/lib/languages/javascript');
+var xml = require('highlight.js/lib/languages/javascript');
+hljs.registerLanguage('javascript', javascript);
+hljs.registerLanguage('xml', xml);
+
+require('angular-highlightjs');

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -1,4 +1,5 @@
 @import "node_modules/bootstrap-sass/assets/stylesheets/bootstrap";
+@import "node_modules/highlight.js/styles/github";
 
 /*
  * Variables
@@ -215,6 +216,12 @@ code {
 
 #noContent {
   color: #ccc;
+}
+
+#req-content {
+  pre {
+    padding: 0;
+  }
 }
 
   /*

--- a/resources/views/app.php
+++ b/resources/views/app.php
@@ -195,9 +195,9 @@
 
                                     <!-- Auto-JSON -->
                                     <label class="small"
-                                           title="Automatically applies easy to read JSON formatting on valid requests">
+                                           title="Automatically applies easy to read JSON and XML formatting on valid requests">
                                         <input type="checkbox" ng-model="formatJsonEnable"
-                                               ga-on="click" ga-event-category="JSONFormat" ga-event-action="toggle"/> Format JSON</label> &emsp;
+                                               ga-on="click" ga-event-category="JSONFormat" ga-event-action="toggle"/> Format JSON/XML</label> &emsp;
 
                                     <!-- Auto Navigate -->
                                     <label class="small"

--- a/resources/views/app.php
+++ b/resources/views/app.php
@@ -321,9 +321,11 @@
                                 <p id="noContent" ng-show="hasRequests && currentRequest.content == ''">
                                     (no body content)</p>
 
-                                <pre id="req-content"
+                                <div id="req-content"
                                      ng-show="hasRequests && currentRequest.content != ''"
-                                     ng-bind="formatJsonEnable ? formatContentJson(currentRequest.content) : currentRequest.content"></pre>
+                                     hljs 
+                                     hljs-source="currentRequest.content">
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Adds support for syntax highlighting of XML and JSON files (#5)

- Just JS/JSON and XML support enabled for now (to optimise JS size)
- Does a shallow copy of the currentRequest (so that when changes are made the original is not overriden)
- Enable formatting in the setCurrentRequest method
- Adds XML pretty printing/formatting as well

Fixes #5 
Fixes #60 