### PR TITLE
Stick FastCGI to IP address to avoid unhandled IPv6 error

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -35,7 +35,7 @@ server {
     # nothing local, let fpm handle it
     location ~ [^/]\.php(/|$) {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass            localhost:9000;
+        fastcgi_pass            127.0.0.1:9000;
         fastcgi_index           index.php;
         include                 fastcgi_params;
         fastcgi_param           REQUEST_METHOD  $request_method;


### PR DESCRIPTION
To avoid this kind of error on Docker env :

```
2019/05/07 16:54:29 [error] 190#190: *9 connect() to [::1]:9000 failed (101: Network unreachable) while connecting to upstream, client: 10.66.60.4, server: application, request: "GET /token/9b22e044-b64a-4a72-a9b4-9e2f732c19d8 HTTP/1.1", upstream: "fastcgi://[::1]:9000", host: "wstest.example.com", referrer: "http://wstest.example.com/"
```