### PR TITLE
Use php 7.4 to resolve security issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN npm run gulp
 # Stage 2: Composer, nginx and fpm
 ##############################################
 
-FROM bkuhl/fpm-nginx:7.3
+FROM bkuhl/fpm-nginx:7.4
 WORKDIR /var/www/html
 
 # Contains laravel echo server proxy configuration

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "pusher/pusher-php-server": "^2.6",
         "doctrine/dbal": "^2.5",
         "predis/predis": "^1.1",
-        "sentry/sentry": "^1.8",
+        "sentry/sentry": "^1.11",
         "sentry/sentry-laravel": "^0.8.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "26aad8fe59dd71553be9964cc8d231e8",
+    "content-hash": "b23095ab54645946356c1185f226aeea",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -1017,16 +1017,16 @@
         },
         {
             "name": "sentry/sentry",
-            "version": "1.10.0",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/getsentry/sentry-php.git",
-                "reference": "b2b8ffe1560b9fb0110b02993594a4b04a511959"
+                "reference": "159eeaa02bb2ef8a8ec669f3c88e4bff7e6a7ffe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/b2b8ffe1560b9fb0110b02993594a4b04a511959",
-                "reference": "b2b8ffe1560b9fb0110b02993594a4b04a511959",
+                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/159eeaa02bb2ef8a8ec669f3c88e4bff7e6a7ffe",
+                "reference": "159eeaa02bb2ef8a8ec669f3c88e4bff7e6a7ffe",
                 "shasum": ""
             },
             "require": {
@@ -1038,7 +1038,7 @@
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^1.8.0",
-                "monolog/monolog": "*",
+                "monolog/monolog": "^1.0",
                 "phpunit/phpunit": "^4.8.35 || ^5.7"
             },
             "suggest": {
@@ -1053,7 +1053,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.10.x-dev"
+                    "dev-master": "1.11.x-dev"
                 }
             },
             "autoload": {
@@ -1077,7 +1077,11 @@
                 "log",
                 "logging"
             ],
-            "time": "2018-11-09T12:27:19+00:00"
+            "support": {
+                "issues": "https://github.com/getsentry/sentry-php/issues",
+                "source": "https://github.com/getsentry/sentry-php/tree/1.11.0"
+            },
+            "time": "2020-02-12T18:38:11+00:00"
         },
         {
             "name": "sentry/sentry-laravel",
@@ -3855,5 +3859,6 @@
     "platform": {
         "php": ">=7.1.0"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
My security scanner was mad at me with webhook.site self host because it was using an old version of php:

```
docker run --rm webhooksite/webhook.site php --version
...
PHP 7.3.5 (cli) (built: May  4 2019 01:32:49) ( NTS )
...
```
That thing is ancient. It's no wonder why the scanner got mad at me :)

This PR upgrades php to 7.4. I had to bump up version of sentry otherwise I would get this error:
```
podman logs webhook-site
...
In Client.php line 1551:

  Undefined variable: version
...
```
which comes from https://github.com/getsentry/sentry-php/blob/1.10.0/lib/Raven/Client.php

sentry 1.11 was the first version where the problem went away.
https://github.com/getsentry/sentry-php/compare/1.10.0...1.11.0

I believe this is what ultimately fixed the issue in sentry 1.11.0:
```diff
-        if ($path{0} === DIRECTORY_SEPARATOR && substr($path, -1) !== DIRECTORY_SEPARATOR) {
+        if (substr($path, 0, 1) === DIRECTORY_SEPARATOR && substr($path, -1) !== DIRECTORY_SEPARATOR) {
            $path .= DIRECTORY_SEPARATOR;
        }
```

I have performed a smoke test by building the docker image and modifying docker compose to use my image:
```
docker build -t webhook-site:php-7.4
...
# modify docker-compose.yml to use my page
...
docker-compose up -d
Network webhooksite_default  Creating
Network webhooksite_default  Created
Container laravel-echo-server  Creating
Container webhook-redis  Creating
Container laravel-echo-server  Created
Container webhook-redis  Created
Container webhook-site  Creating
Container webhook-site  Created
Container laravel-echo-server  Starting
Container webhook-redis  Starting
Container laravel-echo-server  Started
Container webhook-redis  Started
Container webhook-site  Starting
Container webhook-site  Started


docker-compose ps && echo "---" && docker logs webhook-site 2>&1 | tail -20
NAME                  COMMAND                  SERVICE               STATUS              PORTS
laravel-echo-server   "/opt/laravel-echo-s…"   laravel-echo-server   running             6001/tcp
webhook-redis         "docker-entrypoint.s…"   redis                 running             6379/tcp
webhook-site          "/init php artisan q…"   webhook               running             9000/tcp, 0.0.0.0:8085->80/tcp, :::8085->80/tcp, 0.0.0.0:8443->443/tcp, :::8443->443/tcp
---
[s6-init] making user provided files available at /var/run/s6/etc...exited 0.
[s6-init] ensuring user provided files have correct perms...exited 0.
[fix-attrs.d] applying ownership & permissions fixes...
[fix-attrs.d] done.
[cont-init.d] executing container initialization scripts...
[cont-init.d] done.
[services.d] starting services
PHP-FPM's opcache is NOT enabled
[services.d] done.
This account is not available
[21-Jul-2026 17:52:59] NOTICE: fpm is running, pid 189
[21-Jul-2026 17:52:59] NOTICE: ready to handle connections
```

My fork works well enough for me but thought I would give back to the community. Thanks for webhook.site.